### PR TITLE
Setup the RethinkDB by default

### DIFF
--- a/lib/generators/kilt/templates/backend/kilt.rb
+++ b/lib/generators/kilt/templates/backend/kilt.rb
@@ -9,3 +9,6 @@ Settings.reload!
 
 # Attach the Kilt config the content pulled in by RailsConfig
 Kilt.config = Settings
+
+# Ensure we have a database set up
+Kilt::Utils.setup_db


### PR DESCRIPTION
When I created my first Kilt app and tried to create my first object, I got a missing database error.  I created the database, and then I got a missing table error.  I created the table, and the application worked.

I meant to hop in the codebase to add the default creation of these things, but I saw that work has already been done.  It's even called in the dummy app under test, but that setup code is not in the initializer.  

So I just copied the call over.  
