### PR TITLE
Put the types in the menu.

### DIFF
--- a/app/views/layouts/kilt/cms.html.erb
+++ b/app/views/layouts/kilt/cms.html.erb
@@ -22,6 +22,9 @@
         <div class="wr">
             <h6><a href="/admin"><%= Kilt.config.name %></a></h6>
             <a class="button small dashboard" href="/admin">Dashboard</a>
+            <% @types.each do |type| %>
+              <%= link_to type.pluralize.capitalize, list_path(type.pluralize), class: "button small dashboard" %>
+            <% end %>
             <!--
             <div class="user">
                 <span class="greeting">Hello, <span class="user-name">Decimus Meridius</span></span>


### PR DESCRIPTION
Just my thoughts, as someone who has worked with a few dozen RefineryCMS apps...

The default behavior of the menu might be to make an entry for each type that a user might create.  The default dashboard could still provide that same navigation, but it will more likely be used to display some sort of "overall" information or message to a user.

![yawn](https://f.cloud.github.com/assets/148768/1798131/7f5ae030-6b2e-11e3-9407-c9b958aac145.jpg)
