### PR TITLE
/admin can be changed easily

### DIFF
--- a/app/views/layouts/kilt/cms.html.erb
+++ b/app/views/layouts/kilt/cms.html.erb
@@ -20,8 +20,8 @@
 <body>
     <header class="hd">
         <div class="wr">
-            <h6><a href="/admin"><%= Kilt.config.name %></a></h6>
-            <a class="button small dashboard" href="/admin">Dashboard</a>
+            <h6><a href="<%= kilt_engine.root_path %>"><%= Kilt.config.name %></a></h6>
+            <a class="button small dashboard" href="<%= kilt_engine.root_path %>">Dashboard</a>
             <!--
             <div class="user">
                 <span class="greeting">Hello, <span class="user-name">Decimus Meridius</span></span>

--- a/lib/generators/kilt/backend_generator.rb
+++ b/lib/generators/kilt/backend_generator.rb
@@ -12,7 +12,7 @@ module Kilt
         template 'config.yml.erb', Rails.root.join('config', 'kilt', 'config.yml')
         copy_file 'creds.yml.example', Rails.root.join('config', 'kilt', 'creds.yml.example')
         copy_file 'kilt.rb', Rails.root.join('config', 'initializers', 'kilt.rb')
-        inject_into_file Rails.root.join('config', 'routes.rb'), "\n\tmount Kilt::Engine => '/admin'\n", :after => "#{Rails.application.class.parent_name.camelize}::Application.routes.draw do\n"
+        inject_into_file Rails.root.join('config', 'routes.rb'), "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "#{Rails.application.class.parent_name.camelize}::Application.routes.draw do\n"
       end
     end
   end

--- a/lib/generators/kilt/frontend_generator.rb
+++ b/lib/generators/kilt/frontend_generator.rb
@@ -10,7 +10,7 @@ module Kilt
         template 'home_controller.rb.erb', Rails.root.join('app', 'controllers', "#{file_name}_controller.rb")
         copy_file 'application.html.erb', Rails.root.join('app','views','layouts','application.html.erb')
         copy_file 'index.html.erb', Rails.root.join('app', 'views', "#{file_name}", 'index.html.erb')
-        inject_into_file Rails.root.join('config','routes.rb'),"\n\tget '/' => '#{file_name}#index'\n", :after => "mount Kilt::Engine => '/admin'\n"
+        inject_into_file Rails.root.join('config','routes.rb'),"\n\tget '/' => '#{file_name}#index'\n", :after => "mount Kilt::Engine => '/admin', as: 'kilt_engine'\n"
         #handle assets, sans named files
         directory 'assets/images', Rails.root.join('app','assets','images')
         directory 'assets/javascripts', Rails.root.join('app','assets','javascripts')

--- a/lib/generators/kilt/templates/frontend/index.html.erb
+++ b/lib/generators/kilt/templates/frontend/index.html.erb
@@ -1,4 +1,4 @@
-<%= link_to "Admin", "/admin" %>
+<%= link_to "Admin", kilt_engine.root_path %>
 
 <pre>
     <%= Kilt::Utils.tips %>


### PR DESCRIPTION
Another superficial change, but one that I'd use... I removed the hardcoded "/admin" links to a kilt_engine.root_path.  

Not a big deal now, but something to consider as future changes are made.  If a dev changes admin route, the entire application should adjust.
