### PR TITLE
Consolidate to a single database object

### DIFF
--- a/lib/generators/kilt/backend_generator.rb
+++ b/lib/generators/kilt/backend_generator.rb
@@ -12,8 +12,7 @@ module Kilt
         template 'config.yml.erb', Rails.root.join('config', 'kilt', 'config.yml')
         copy_file 'creds.yml.example', Rails.root.join('config', 'kilt', 'creds.yml.example')
         copy_file 'kilt.rb', Rails.root.join('config', 'initializers', 'kilt.rb')
-        inject_into_file Rails.root.join('config', 'routes.rb'), "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "#{Rails.application.class.parent_name.camelize}::Application.routes.draw do\n"
-        inject_into_file Rails.root.join('config', 'routes.rb'), "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "Rails.application.routes.draw do\n"
+        inject_into_file Rails.root.join('config', 'routes.rb'), "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => ".routes.draw do\n"
       
       end
     end

--- a/lib/generators/kilt/backend_generator.rb
+++ b/lib/generators/kilt/backend_generator.rb
@@ -13,6 +13,7 @@ module Kilt
         copy_file 'creds.yml.example', Rails.root.join('config', 'kilt', 'creds.yml.example')
         copy_file 'kilt.rb', Rails.root.join('config', 'initializers', 'kilt.rb')
         inject_into_file Rails.root.join('config', 'routes.rb'), "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "#{Rails.application.class.parent_name.camelize}::Application.routes.draw do\n"
+        inject_into_file Rails.root.join('config', 'routes.rb'), "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "Rails.application.routes.draw do\n"
       
       end
     end

--- a/lib/generators/kilt/templates/backend/kilt.rb
+++ b/lib/generators/kilt/templates/backend/kilt.rb
@@ -11,4 +11,4 @@ Settings.reload!
 Kilt.config = Settings
 
 # Ensure we have a database set up
-Kilt::Utils.setup_rethink_db
+Kilt::Utils.setup_db

--- a/lib/generators/kilt/templates/backend/kilt.rb
+++ b/lib/generators/kilt/templates/backend/kilt.rb
@@ -11,4 +11,4 @@ Settings.reload!
 Kilt.config = Settings
 
 # Ensure we have a database set up
-Kilt::Utils.setup_db
+Kilt::Utils.setup_rethink_db

--- a/lib/kilt/database.rb
+++ b/lib/kilt/database.rb
@@ -35,6 +35,39 @@ module Kilt
       result['errors'] == 0
     end
 
+    def self.setup!
+      if Kilt.config.db.host && Kilt.config.db.port
+        begin
+          db = r.connect(:host => Kilt.config.db.host, :port => Kilt.config.db.port).repl
+        rescue
+          raise Kilt::CantConnectToDatabaseError
+        end
+
+        begin
+          #
+          # See if the db exists and create it otherwise
+          dbs = r.db_list.run
+          if !dbs.to_a.include? Kilt.config.db.db
+            r.db_create(Kilt.config.db.db).run
+          end
+          #
+          # See if the table exists and create it otherwise
+          tables = r.db(Kilt.config.db.db).table_list.run
+          if !tables.to_a.include? "objects"
+            r.db(Kilt.config.db.db).table_create("objects", :primary_key => "unique_id").run
+          end
+
+        rescue
+          raise Kilt::CantSetupDatabaseError
+        ensure
+          db.close
+        end
+
+      else
+        raise Kilt::NoDatabaseConfigError
+      end
+    end
+
     private
 
     def objects_table

--- a/lib/kilt/database.rb
+++ b/lib/kilt/database.rb
@@ -41,10 +41,10 @@ module Kilt
       block.call
     end
 
-    def self.setup!
-      if Kilt.config.db.host && Kilt.config.db.port
+    def self.setup!(options)
+      if options[:host] && options[:port]
         begin
-          db = r.connect(:host => Kilt.config.db.host, :port => Kilt.config.db.port).repl
+          db = r.connect(:host => options[:host], :port => options[:port]).repl
         rescue
           raise Kilt::CantConnectToDatabaseError
         end
@@ -53,14 +53,14 @@ module Kilt
           #
           # See if the db exists and create it otherwise
           dbs = r.db_list.run
-          if !dbs.to_a.include? Kilt.config.db.db
-            r.db_create(Kilt.config.db.db).run
+          if !dbs.to_a.include? options[:db]
+            r.db_create(options[:db]).run
           end
           #
           # See if the table exists and create it otherwise
-          tables = r.db(Kilt.config.db.db).table_list.run
+          tables = r.db(options[:db]).table_list.run
           if !tables.to_a.include? "objects"
-            r.db(Kilt.config.db.db).table_create("objects", :primary_key => "unique_id").run
+            r.db(options[:db]).table_create("objects", :primary_key => "unique_id").run
           end
 
         rescue
@@ -77,7 +77,7 @@ module Kilt
     private
 
     def objects_table
-      r.db(Kilt.config.db.db).table('objects')
+      r.db(@options[:db]).table('objects')
     end
 
     def slug_query(slug)

--- a/lib/kilt/database.rb
+++ b/lib/kilt/database.rb
@@ -7,7 +7,7 @@ module Kilt
     end
 
     def find(slug)
-      results = Utils.db { slug_query(slug).limit(1).run }
+      results = execute { slug_query(slug).limit(1).run }
       return nil unless results
       results = results.to_a
       return nil if results.first.is_a? Array
@@ -15,24 +15,30 @@ module Kilt
     end
 
     def find_all_by_type type
-      Utils.db { type_query(type).run }.to_a
+      execute { type_query(type).run }.to_a
     end
 
     def create(object)
-      result = Utils.db { objects_table.insert(object.values).run }
+      result = execute { objects_table.insert(object.values).run }
       result['errors'] == 0
     end
 
     def update(object)
-      result = Utils.db do
+      result = execute do
         unique_id_query(object['unique_id']).update(object.values).run
       end
       result['errors'] == 0
     end
 
     def delete(slug)
-      result = Utils.db { slug_query(slug).delete().run }
+      result = execute { slug_query(slug).delete().run }
       result['errors'] == 0
+    end
+
+    # Make a db call
+    def execute(&block)
+      @db ||= r.connect(:host => @options[:host], :port => @options[:port]).repl
+      block.call
     end
 
     def self.setup!

--- a/lib/kilt/database.rb
+++ b/lib/kilt/database.rb
@@ -41,10 +41,10 @@ module Kilt
       block.call
     end
 
-    def self.setup!(options)
-      if options[:host] && options[:port]
+    def setup!
+      if @options[:host] && @options[:port]
         begin
-          db = r.connect(:host => options[:host], :port => options[:port]).repl
+          db = r.connect(:host => @options[:host], :port => @options[:port]).repl
         rescue
           raise Kilt::CantConnectToDatabaseError
         end
@@ -53,14 +53,14 @@ module Kilt
           #
           # See if the db exists and create it otherwise
           dbs = r.db_list.run
-          if !dbs.to_a.include? options[:db]
-            r.db_create(options[:db]).run
+          if !dbs.to_a.include? @options[:db]
+            r.db_create(@options[:db]).run
           end
           #
           # See if the table exists and create it otherwise
-          tables = r.db(options[:db]).table_list.run
+          tables = r.db(@options[:db]).table_list.run
           if !tables.to_a.include? "objects"
-            r.db(options[:db]).table_create("objects", :primary_key => "unique_id").run
+            r.db(@options[:db]).table_create("objects", :primary_key => "unique_id").run
           end
 
         rescue

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -3,7 +3,7 @@ module Kilt
     
     # Set up the database
     def self.rethink_setup_db
-      Kilt::Database.setup! Kilt.config.db
+      Kilt::Database.new(Kilt.config.db).setup!
     end
     
     def self.database

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -3,36 +3,7 @@ module Kilt
     
     # Set up the database
     def self.rethink_setup_db
-      if Kilt.config.db.host && Kilt.config.db.port
-        begin
-          db = r.connect(:host => Kilt.config.db.host, :port => Kilt.config.db.port).repl
-        rescue
-          raise Kilt::CantConnectToDatabaseError 
-        end
-        
-        begin
-          
-          # See if the db exists and create it otherwise
-          dbs = r.db_list.run
-          if !dbs.to_a.include? Kilt.config.db.db
-            r.db_create(Kilt.config.db.db).run
-          end
-          
-          # See if the table exists and create it otherwise
-          tables = r.db(Kilt.config.db.db).table_list.run
-          if !tables.to_a.include? "objects"
-            r.db(Kilt.config.db.db).table_create("objects", :primary_key => "unique_id").run
-          end
-      
-        rescue
-          raise Kilt::CantSetupDatabaseError
-        ensure
-          db.close
-        end
-        
-      else
-        raise Kilt::NoDatabaseConfigError
-      end
+      Kilt::Database.setup!
     end
     
     # Make a db call

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -6,12 +6,6 @@ module Kilt
       Kilt::Database.setup!
     end
     
-    # Make a db call
-    def self.db(&block)
-      @db ||= r.connect(:host => Kilt.config.db.host, :port => Kilt.config.db.port).repl
-      block.call
-    end
-
     def self.database
       @database ||= Kilt::Database.new(:host => Kilt.config.db.host, :port => Kilt.config.db.port)
     end

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -1,8 +1,7 @@
 module Kilt
   class Utils
     
-    # Set up the database
-    def self.rethink_setup_db
+    def self.setup_db
       Kilt::Database.new(Kilt.config.db).setup!
     end
     

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -3,11 +3,11 @@ module Kilt
     
     # Set up the database
     def self.rethink_setup_db
-      Kilt::Database.setup!
+      Kilt::Database.setup! Kilt.config.db
     end
     
     def self.database
-      @database ||= Kilt::Database.new(:host => Kilt.config.db.host, :port => Kilt.config.db.port)
+      @database ||= Kilt::Database.new Kilt.config.db
     end
     
     # Ensure we have local storage dirs

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -2,7 +2,7 @@ module Kilt
   class Utils
     
     # Set up the database
-    def self.setup_db
+    def self.rethink_setup_db
       if Kilt.config.db.host && Kilt.config.db.port
         begin
           db = r.connect(:host => Kilt.config.db.host, :port => Kilt.config.db.port).repl

--- a/test/dummy/config/initializers/kilt.rb
+++ b/test/dummy/config/initializers/kilt.rb
@@ -11,4 +11,4 @@ Settings.reload!
 Kilt.config = Settings
 
 # Ensure we have a database set up
-Kilt::Utils.setup_db
+Kilt::Utils.rethink_setup_db

--- a/test/dummy/config/initializers/kilt.rb
+++ b/test/dummy/config/initializers/kilt.rb
@@ -11,4 +11,4 @@ Settings.reload!
 Kilt.config = Settings
 
 # Ensure we have a database set up
-Kilt::Utils.rethink_setup_db
+Kilt::Utils.setup_db

--- a/test/generators/kilt/backend_generator_spec.rb
+++ b/test/generators/kilt/backend_generator_spec.rb
@@ -51,17 +51,10 @@ describe Kilt::Generators::BackendGenerator do
       generator.generate
     end
 
-    it "should inject the Kilt routes into a Rails 4.0 app's routes" do
+    it "should inject the Kilt routes into the app's routes" do
       root_result = Object.new
       root.stubs(:join).with('config', 'routes.rb').returns root_result
-      generator.expects(:inject_into_file).with root_result, "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "Test::Application.routes.draw do\n"
-      generator.generate
-    end
-
-    it "should inject the Kilt routes into a Rails 4.1 app's routes" do
-      root_result = Object.new
-      root.stubs(:join).with('config', 'routes.rb').returns root_result
-      generator.expects(:inject_into_file).with root_result, "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "Rails.application.routes.draw do\n"
+      generator.expects(:inject_into_file).with root_result, "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => ".routes.draw do\n"
       generator.generate
     end
 

--- a/test/generators/kilt/backend_generator_spec.rb
+++ b/test/generators/kilt/backend_generator_spec.rb
@@ -1,0 +1,45 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../minitest_helper')
+require 'rails/generators'
+require_relative '../../../lib/generators/kilt/backend_generator'
+
+describe Kilt::Generators::BackendGenerator do
+
+  it "should exist" do
+    #raise Kilt::Generators::BackendGenerator.new.destination_root.inspect
+    #raise Kilt::Generators::BackendGenerator.new.public_methods(true).inspect
+    #raise Kilt::Generators::BackendGenerator.new.public_methods(true).inspect
+  end
+
+  describe "generate" do
+
+    let(:generator) { Kilt::Generators::BackendGenerator.new }
+
+    let(:root) do
+      Object.new
+    end
+
+    let(:parent_name) { 'test' }
+
+    before do
+      generator.stubs(:template)
+      generator.stubs(:copy_file)
+      generator.stubs(:inject_into_file)
+
+      Rails.stubs(:root).returns root
+
+      root.stubs(:join)
+
+      application = Object.new
+      klass       = Object.new
+      Rails.stubs(:application).returns application
+      application.stubs(:class).returns klass
+      klass.stubs(:parent_name).returns parent_name
+    end
+
+    it "should be able to be called without erroring" do
+      generator.generate
+    end
+
+  end
+
+end

--- a/test/generators/kilt/backend_generator_spec.rb
+++ b/test/generators/kilt/backend_generator_spec.rb
@@ -51,10 +51,17 @@ describe Kilt::Generators::BackendGenerator do
       generator.generate
     end
 
-    it "should inject the Kilt routes into the app's routes" do
+    it "should inject the Kilt routes into a Rails 4.0 app's routes" do
       root_result = Object.new
       root.stubs(:join).with('config', 'routes.rb').returns root_result
       generator.expects(:inject_into_file).with root_result, "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "Test::Application.routes.draw do\n"
+      generator.generate
+    end
+
+    it "should inject the Kilt routes into a Rails 4.1 app's routes" do
+      root_result = Object.new
+      root.stubs(:join).with('config', 'routes.rb').returns root_result
+      generator.expects(:inject_into_file).with root_result, "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "Rails.application.routes.draw do\n"
       generator.generate
     end
 

--- a/test/generators/kilt/backend_generator_spec.rb
+++ b/test/generators/kilt/backend_generator_spec.rb
@@ -4,12 +4,6 @@ require_relative '../../../lib/generators/kilt/backend_generator'
 
 describe Kilt::Generators::BackendGenerator do
 
-  it "should exist" do
-    #raise Kilt::Generators::BackendGenerator.new.destination_root.inspect
-    #raise Kilt::Generators::BackendGenerator.new.public_methods(true).inspect
-    #raise Kilt::Generators::BackendGenerator.new.public_methods(true).inspect
-  end
-
   describe "generate" do
 
     let(:generator) { Kilt::Generators::BackendGenerator.new }
@@ -18,7 +12,7 @@ describe Kilt::Generators::BackendGenerator do
       Object.new
     end
 
-    let(:parent_name) { 'test' }
+    let(:parent_name) { 'Test' }
 
     before do
       generator.stubs(:template)
@@ -36,7 +30,31 @@ describe Kilt::Generators::BackendGenerator do
       klass.stubs(:parent_name).returns parent_name
     end
 
-    it "should be able to be called without erroring" do
+    it "should copy the default config file to the app" do
+      root_result = Object.new
+      root.stubs(:join).with('config', 'kilt', 'config.yml').returns root_result
+      generator.expects(:template).with 'config.yml.erb', root_result
+      generator.generate
+    end
+
+    it "should copy the default credential file to the app" do
+      root_result = Object.new
+      root.stubs(:join).with('config', 'kilt', 'creds.yml.example').returns root_result
+      generator.expects(:copy_file).with 'creds.yml.example', root_result
+      generator.generate
+    end
+
+    it "should copy the kilt.rb file as an app initializer" do
+      root_result = Object.new
+      root.stubs(:join).with('config', 'initializers', 'kilt.rb').returns root_result
+      generator.expects(:copy_file).with 'kilt.rb', root_result
+      generator.generate
+    end
+
+    it "should inject the Kilt routes into the app's routes" do
+      root_result = Object.new
+      root.stubs(:join).with('config', 'routes.rb').returns root_result
+      generator.expects(:inject_into_file).with root_result, "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "Test::Application.routes.draw do\n"
       generator.generate
     end
 

--- a/test/kilt_spec.rb
+++ b/test/kilt_spec.rb
@@ -103,7 +103,7 @@ describe Kilt do
       describe "when creating a record fails" do
 
         it "should return false" do
-          Kilt::Utils.stubs(:db).returns( { 'errors' => error_count } )
+          Kilt::Database.any_instance.stubs(:execute).returns( { 'errors' => error_count } )
           object = Kilt::Object.new('dog', { 'name' => 'A name.' } )
           Kilt.create(object).must_equal false
         end
@@ -378,7 +378,7 @@ describe Kilt do
     end
 
     it "should return false if the delete returned errors" do
-      Kilt::Utils.stubs(:db).returns( { 'errors' => 1 } )
+      Kilt::Database.any_instance.stubs(:execute).returns( { 'errors' => 1 } )
       Kilt.delete(object['slug']).must_equal false
     end
 

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -27,7 +27,7 @@ end
 
 def setup_the_database_with config
   Kilt.config = config
-  Kilt::Utils.rethink_setup_db
+  Kilt::Utils.setup_db
 end
 
 def clear_out_the_database

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -31,7 +31,7 @@ def setup_the_database_with config
 end
 
 def clear_out_the_database
-  Kilt::Utils.db do
+  Kilt::Database.new(:host => Kilt.config.db.host, :port => Kilt.config.db.port).execute do
     r.db(Kilt.config.db.db).table('objects').delete().run
   end
 end

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -31,7 +31,7 @@ def setup_the_database_with config
 end
 
 def clear_out_the_database
-  Kilt::Database.new(:host => Kilt.config.db.host, :port => Kilt.config.db.port).execute do
+  Kilt::Database.new(Kilt.config.db).execute do
     r.db(Kilt.config.db.db).table('objects').delete().run
   end
 end

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -31,7 +31,7 @@ def setup_the_database_with config
 end
 
 def clear_out_the_database
-  Kilt::Database.new(Kilt.config.db).execute do
+  Kilt::Utils.database.execute do
     r.db(Kilt.config.db.db).table('objects').delete().run
   end
 end

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -27,7 +27,7 @@ end
 
 def setup_the_database_with config
   Kilt.config = config
-  Kilt::Utils.setup_db
+  Kilt::Utils.rethink_setup_db
 end
 
 def clear_out_the_database


### PR DESCRIPTION
Not ready for production, but it is ready for review and comment.  I'd like to run a few more tests against a Rails 4 & 4.1 app before this is merged.

What I've done here is consolidate all of the database operations (that I could see) into a single "database" object.  I believe this is the first step towards support more databases, as this database object could be replaced with one hooked to ActiveRecord, or MongoDB, or whatever, and the rest of the system would adjust.  

Also, by isolating the database operations, making changes like a different configuration per environment becomes trivial.
