### PR TITLE
Environment level config

### DIFF
--- a/lib/generators/kilt/backend_generator.rb
+++ b/lib/generators/kilt/backend_generator.rb
@@ -12,8 +12,7 @@ module Kilt
         template 'config.yml.erb', Rails.root.join('config', 'kilt', 'config.yml')
         copy_file 'creds.yml.example', Rails.root.join('config', 'kilt', 'creds.yml.example')
         copy_file 'kilt.rb', Rails.root.join('config', 'initializers', 'kilt.rb')
-        inject_into_file Rails.root.join('config', 'routes.rb'), "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "#{Rails.application.class.parent_name.camelize}::Application.routes.draw do\n"
-        inject_into_file Rails.root.join('config', 'routes.rb'), "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "Rails.application.routes.draw do\n"
+        inject_into_file Rails.root.join('config', 'routes.rb'), "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => ".routes.draw do\n"
       
       end
     end

--- a/lib/generators/kilt/backend_generator.rb
+++ b/lib/generators/kilt/backend_generator.rb
@@ -13,6 +13,7 @@ module Kilt
         copy_file 'creds.yml.example', Rails.root.join('config', 'kilt', 'creds.yml.example')
         copy_file 'kilt.rb', Rails.root.join('config', 'initializers', 'kilt.rb')
         inject_into_file Rails.root.join('config', 'routes.rb'), "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "#{Rails.application.class.parent_name.camelize}::Application.routes.draw do\n"
+        inject_into_file Rails.root.join('config', 'routes.rb'), "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "Rails.application.routes.draw do\n"
       
       end
     end

--- a/lib/generators/kilt/templates/backend/creds.yml.example
+++ b/lib/generators/kilt/templates/backend/creds.yml.example
@@ -1,7 +1,18 @@
-db:
-  host: <DB host>
-  port: <DB port>
-  db: <DB database>
+test:
+  db:
+    host: 127.0.0.1
+    port: 28015
+    db: my_app_test
+development:
+  db:
+    host: 127.0.0.1
+    port: 28015
+    db: my_app_development
+production:
+  db:
+    host: ENV['KILT_HOST']
+    port: ENV['KILT_PORT']
+    db: ENV['KILT_DB']
 s3:
   key: <S3 key>
   secret: <S3 secret>

--- a/lib/generators/kilt/templates/backend/kilt.rb
+++ b/lib/generators/kilt/templates/backend/kilt.rb
@@ -11,4 +11,4 @@ Settings.reload!
 Kilt.config = Settings
 
 # Ensure we have a database set up
-Kilt::Utils.setup_rethink_db
+Kilt::Utils.setup_db

--- a/lib/generators/kilt/templates/backend/kilt.rb
+++ b/lib/generators/kilt/templates/backend/kilt.rb
@@ -11,4 +11,4 @@ Settings.reload!
 Kilt.config = Settings
 
 # Ensure we have a database set up
-Kilt::Utils.setup_db
+Kilt::Utils.setup_rethink_db

--- a/lib/kilt/database.rb
+++ b/lib/kilt/database.rb
@@ -35,6 +35,39 @@ module Kilt
       result['errors'] == 0
     end
 
+    def self.setup!
+      if Kilt.config.db.host && Kilt.config.db.port
+        begin
+          db = r.connect(:host => Kilt.config.db.host, :port => Kilt.config.db.port).repl
+        rescue
+          raise Kilt::CantConnectToDatabaseError
+        end
+
+        begin
+          #
+          # See if the db exists and create it otherwise
+          dbs = r.db_list.run
+          if !dbs.to_a.include? Kilt.config.db.db
+            r.db_create(Kilt.config.db.db).run
+          end
+          #
+          # See if the table exists and create it otherwise
+          tables = r.db(Kilt.config.db.db).table_list.run
+          if !tables.to_a.include? "objects"
+            r.db(Kilt.config.db.db).table_create("objects", :primary_key => "unique_id").run
+          end
+
+        rescue
+          raise Kilt::CantSetupDatabaseError
+        ensure
+          db.close
+        end
+
+      else
+        raise Kilt::NoDatabaseConfigError
+      end
+    end
+
     private
 
     def objects_table

--- a/lib/kilt/database.rb
+++ b/lib/kilt/database.rb
@@ -41,10 +41,10 @@ module Kilt
       block.call
     end
 
-    def self.setup!
-      if Kilt.config.db.host && Kilt.config.db.port
+    def self.setup!(options)
+      if options[:host] && options[:port]
         begin
-          db = r.connect(:host => Kilt.config.db.host, :port => Kilt.config.db.port).repl
+          db = r.connect(:host => options[:host], :port => options[:port]).repl
         rescue
           raise Kilt::CantConnectToDatabaseError
         end
@@ -53,14 +53,14 @@ module Kilt
           #
           # See if the db exists and create it otherwise
           dbs = r.db_list.run
-          if !dbs.to_a.include? Kilt.config.db.db
-            r.db_create(Kilt.config.db.db).run
+          if !dbs.to_a.include? options[:db]
+            r.db_create(options[:db]).run
           end
           #
           # See if the table exists and create it otherwise
-          tables = r.db(Kilt.config.db.db).table_list.run
+          tables = r.db(options[:db]).table_list.run
           if !tables.to_a.include? "objects"
-            r.db(Kilt.config.db.db).table_create("objects", :primary_key => "unique_id").run
+            r.db(options[:db]).table_create("objects", :primary_key => "unique_id").run
           end
 
         rescue
@@ -77,7 +77,7 @@ module Kilt
     private
 
     def objects_table
-      r.db(Kilt.config.db.db).table('objects')
+      r.db(@options[:db]).table('objects')
     end
 
     def slug_query(slug)

--- a/lib/kilt/database.rb
+++ b/lib/kilt/database.rb
@@ -7,7 +7,7 @@ module Kilt
     end
 
     def find(slug)
-      results = Utils.db { slug_query(slug).limit(1).run }
+      results = execute { slug_query(slug).limit(1).run }
       return nil unless results
       results = results.to_a
       return nil if results.first.is_a? Array
@@ -15,24 +15,30 @@ module Kilt
     end
 
     def find_all_by_type type
-      Utils.db { type_query(type).run }.to_a
+      execute { type_query(type).run }.to_a
     end
 
     def create(object)
-      result = Utils.db { objects_table.insert(object.values).run }
+      result = execute { objects_table.insert(object.values).run }
       result['errors'] == 0
     end
 
     def update(object)
-      result = Utils.db do
+      result = execute do
         unique_id_query(object['unique_id']).update(object.values).run
       end
       result['errors'] == 0
     end
 
     def delete(slug)
-      result = Utils.db { slug_query(slug).delete().run }
+      result = execute { slug_query(slug).delete().run }
       result['errors'] == 0
+    end
+
+    # Make a db call
+    def execute(&block)
+      @db ||= r.connect(:host => @options[:host], :port => @options[:port]).repl
+      block.call
     end
 
     def self.setup!

--- a/lib/kilt/database.rb
+++ b/lib/kilt/database.rb
@@ -41,10 +41,10 @@ module Kilt
       block.call
     end
 
-    def self.setup!(options)
-      if options[:host] && options[:port]
+    def setup!
+      if @options[:host] && @options[:port]
         begin
-          db = r.connect(:host => options[:host], :port => options[:port]).repl
+          db = r.connect(:host => @options[:host], :port => @options[:port]).repl
         rescue
           raise Kilt::CantConnectToDatabaseError
         end
@@ -53,14 +53,14 @@ module Kilt
           #
           # See if the db exists and create it otherwise
           dbs = r.db_list.run
-          if !dbs.to_a.include? options[:db]
-            r.db_create(options[:db]).run
+          if !dbs.to_a.include? @options[:db]
+            r.db_create(@options[:db]).run
           end
           #
           # See if the table exists and create it otherwise
-          tables = r.db(options[:db]).table_list.run
+          tables = r.db(@options[:db]).table_list.run
           if !tables.to_a.include? "objects"
-            r.db(options[:db]).table_create("objects", :primary_key => "unique_id").run
+            r.db(@options[:db]).table_create("objects", :primary_key => "unique_id").run
           end
 
         rescue

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -7,7 +7,11 @@ module Kilt
     
     def self.database
       current_environment = (ENV['RAILS_ENV'].to_s == '' ? 'development' : ENV['RAILS_ENV']).to_sym
-      db_config = Kilt.config.send(current_environment).db
+      db_config = begin
+                    Kilt.config.send(current_environment).db
+                  rescue
+                    Kilt.config.db
+                  end
       @database ||= Kilt::Database.new db_config
     end
     

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -3,7 +3,7 @@ module Kilt
     
     # Set up the database
     def self.rethink_setup_db
-      Kilt::Database.setup! Kilt.config.db
+      Kilt::Database.new(Kilt.config.db).setup!
     end
     
     def self.database

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -3,36 +3,7 @@ module Kilt
     
     # Set up the database
     def self.rethink_setup_db
-      if Kilt.config.db.host && Kilt.config.db.port
-        begin
-          db = r.connect(:host => Kilt.config.db.host, :port => Kilt.config.db.port).repl
-        rescue
-          raise Kilt::CantConnectToDatabaseError 
-        end
-        
-        begin
-          
-          # See if the db exists and create it otherwise
-          dbs = r.db_list.run
-          if !dbs.to_a.include? Kilt.config.db.db
-            r.db_create(Kilt.config.db.db).run
-          end
-          
-          # See if the table exists and create it otherwise
-          tables = r.db(Kilt.config.db.db).table_list.run
-          if !tables.to_a.include? "objects"
-            r.db(Kilt.config.db.db).table_create("objects", :primary_key => "unique_id").run
-          end
-      
-        rescue
-          raise Kilt::CantSetupDatabaseError
-        ensure
-          db.close
-        end
-        
-      else
-        raise Kilt::NoDatabaseConfigError
-      end
+      Kilt::Database.setup!
     end
     
     # Make a db call

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -6,13 +6,14 @@ module Kilt
     end
     
     def self.database
+      @database ||= Kilt::Database.new current_db_config
+    end
+
+    def self.current_db_config
       current_environment = (ENV['RAILS_ENV'].to_s == '' ? 'development' : ENV['RAILS_ENV']).to_sym
-      db_config = begin
-                    Kilt.config[current_environment].db
-                  rescue
-                    Kilt.config.db
-                  end
-      @database ||= Kilt::Database.new db_config
+      Kilt.config[current_environment].db
+    rescue
+      Kilt.config.db
     end
     
     # Ensure we have local storage dirs

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -8,7 +8,7 @@ module Kilt
     def self.database
       current_environment = (ENV['RAILS_ENV'].to_s == '' ? 'development' : ENV['RAILS_ENV']).to_sym
       db_config = begin
-                    Kilt.config.send(current_environment).db
+                    Kilt.config[current_environment].db
                   rescue
                     Kilt.config.db
                   end

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -6,12 +6,6 @@ module Kilt
       Kilt::Database.setup!
     end
     
-    # Make a db call
-    def self.db(&block)
-      @db ||= r.connect(:host => Kilt.config.db.host, :port => Kilt.config.db.port).repl
-      block.call
-    end
-
     def self.database
       @database ||= Kilt::Database.new(:host => Kilt.config.db.host, :port => Kilt.config.db.port)
     end

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -6,7 +6,8 @@ module Kilt
     end
     
     def self.database
-      db_config = Kilt.config.send(ENV['RAILS_ENV'].to_sym).db
+      current_environment = (ENV['RAILS_ENV'].to_s == '' ? 'development' : ENV['RAILS_ENV']).to_sym
+      db_config = Kilt.config.send(current_environment).db
       @database ||= Kilt::Database.new db_config
     end
     

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -1,8 +1,7 @@
 module Kilt
   class Utils
     
-    # Set up the database
-    def self.rethink_setup_db
+    def self.setup_db
       Kilt::Database.new(Kilt.config.db).setup!
     end
     

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -6,7 +6,8 @@ module Kilt
     end
     
     def self.database
-      @database ||= Kilt::Database.new Kilt.config.test.db
+      db_config = Kilt.config.send(ENV['RAILS_ENV'].to_sym).db
+      @database ||= Kilt::Database.new db_config
     end
     
     # Ensure we have local storage dirs

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -2,7 +2,7 @@ module Kilt
   class Utils
     
     def self.setup_db
-      Kilt::Database.new(Kilt.config.test.db).setup!
+      database.setup!
     end
     
     def self.database

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -2,11 +2,11 @@ module Kilt
   class Utils
     
     def self.setup_db
-      Kilt::Database.new(Kilt.config.db).setup!
+      Kilt::Database.new(Kilt.config.test.db).setup!
     end
     
     def self.database
-      @database ||= Kilt::Database.new Kilt.config.db
+      @database ||= Kilt::Database.new Kilt.config.test.db
     end
     
     # Ensure we have local storage dirs

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -3,11 +3,11 @@ module Kilt
     
     # Set up the database
     def self.rethink_setup_db
-      Kilt::Database.setup!
+      Kilt::Database.setup! Kilt.config.db
     end
     
     def self.database
-      @database ||= Kilt::Database.new(:host => Kilt.config.db.host, :port => Kilt.config.db.port)
+      @database ||= Kilt::Database.new Kilt.config.db
     end
     
     # Ensure we have local storage dirs

--- a/lib/kilt/utils.rb
+++ b/lib/kilt/utils.rb
@@ -2,7 +2,7 @@ module Kilt
   class Utils
     
     # Set up the database
-    def self.setup_db
+    def self.rethink_setup_db
       if Kilt.config.db.host && Kilt.config.db.port
         begin
           db = r.connect(:host => Kilt.config.db.host, :port => Kilt.config.db.port).repl

--- a/test/dummy/config/initializers/kilt.rb
+++ b/test/dummy/config/initializers/kilt.rb
@@ -11,4 +11,4 @@ Settings.reload!
 Kilt.config = Settings
 
 # Ensure we have a database set up
-Kilt::Utils.setup_db
+Kilt::Utils.rethink_setup_db

--- a/test/dummy/config/initializers/kilt.rb
+++ b/test/dummy/config/initializers/kilt.rb
@@ -11,4 +11,4 @@ Settings.reload!
 Kilt.config = Settings
 
 # Ensure we have a database set up
-Kilt::Utils.rethink_setup_db
+Kilt::Utils.setup_db

--- a/test/generators/kilt/backend_generator_spec.rb
+++ b/test/generators/kilt/backend_generator_spec.rb
@@ -51,17 +51,10 @@ describe Kilt::Generators::BackendGenerator do
       generator.generate
     end
 
-    it "should inject the Kilt routes into a Rails 4.0 app's routes" do
+    it "should inject the Kilt routes into the app's routes" do
       root_result = Object.new
       root.stubs(:join).with('config', 'routes.rb').returns root_result
-      generator.expects(:inject_into_file).with root_result, "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "Test::Application.routes.draw do\n"
-      generator.generate
-    end
-
-    it "should inject the Kilt routes into a Rails 4.1 app's routes" do
-      root_result = Object.new
-      root.stubs(:join).with('config', 'routes.rb').returns root_result
-      generator.expects(:inject_into_file).with root_result, "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "Rails.application.routes.draw do\n"
+      generator.expects(:inject_into_file).with root_result, "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => ".routes.draw do\n"
       generator.generate
     end
 

--- a/test/generators/kilt/backend_generator_spec.rb
+++ b/test/generators/kilt/backend_generator_spec.rb
@@ -1,0 +1,45 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../minitest_helper')
+require 'rails/generators'
+require_relative '../../../lib/generators/kilt/backend_generator'
+
+describe Kilt::Generators::BackendGenerator do
+
+  it "should exist" do
+    #raise Kilt::Generators::BackendGenerator.new.destination_root.inspect
+    #raise Kilt::Generators::BackendGenerator.new.public_methods(true).inspect
+    #raise Kilt::Generators::BackendGenerator.new.public_methods(true).inspect
+  end
+
+  describe "generate" do
+
+    let(:generator) { Kilt::Generators::BackendGenerator.new }
+
+    let(:root) do
+      Object.new
+    end
+
+    let(:parent_name) { 'test' }
+
+    before do
+      generator.stubs(:template)
+      generator.stubs(:copy_file)
+      generator.stubs(:inject_into_file)
+
+      Rails.stubs(:root).returns root
+
+      root.stubs(:join)
+
+      application = Object.new
+      klass       = Object.new
+      Rails.stubs(:application).returns application
+      application.stubs(:class).returns klass
+      klass.stubs(:parent_name).returns parent_name
+    end
+
+    it "should be able to be called without erroring" do
+      generator.generate
+    end
+
+  end
+
+end

--- a/test/generators/kilt/backend_generator_spec.rb
+++ b/test/generators/kilt/backend_generator_spec.rb
@@ -51,10 +51,17 @@ describe Kilt::Generators::BackendGenerator do
       generator.generate
     end
 
-    it "should inject the Kilt routes into the app's routes" do
+    it "should inject the Kilt routes into a Rails 4.0 app's routes" do
       root_result = Object.new
       root.stubs(:join).with('config', 'routes.rb').returns root_result
       generator.expects(:inject_into_file).with root_result, "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "Test::Application.routes.draw do\n"
+      generator.generate
+    end
+
+    it "should inject the Kilt routes into a Rails 4.1 app's routes" do
+      root_result = Object.new
+      root.stubs(:join).with('config', 'routes.rb').returns root_result
+      generator.expects(:inject_into_file).with root_result, "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "Rails.application.routes.draw do\n"
       generator.generate
     end
 

--- a/test/generators/kilt/backend_generator_spec.rb
+++ b/test/generators/kilt/backend_generator_spec.rb
@@ -4,12 +4,6 @@ require_relative '../../../lib/generators/kilt/backend_generator'
 
 describe Kilt::Generators::BackendGenerator do
 
-  it "should exist" do
-    #raise Kilt::Generators::BackendGenerator.new.destination_root.inspect
-    #raise Kilt::Generators::BackendGenerator.new.public_methods(true).inspect
-    #raise Kilt::Generators::BackendGenerator.new.public_methods(true).inspect
-  end
-
   describe "generate" do
 
     let(:generator) { Kilt::Generators::BackendGenerator.new }
@@ -18,7 +12,7 @@ describe Kilt::Generators::BackendGenerator do
       Object.new
     end
 
-    let(:parent_name) { 'test' }
+    let(:parent_name) { 'Test' }
 
     before do
       generator.stubs(:template)
@@ -36,7 +30,31 @@ describe Kilt::Generators::BackendGenerator do
       klass.stubs(:parent_name).returns parent_name
     end
 
-    it "should be able to be called without erroring" do
+    it "should copy the default config file to the app" do
+      root_result = Object.new
+      root.stubs(:join).with('config', 'kilt', 'config.yml').returns root_result
+      generator.expects(:template).with 'config.yml.erb', root_result
+      generator.generate
+    end
+
+    it "should copy the default credential file to the app" do
+      root_result = Object.new
+      root.stubs(:join).with('config', 'kilt', 'creds.yml.example').returns root_result
+      generator.expects(:copy_file).with 'creds.yml.example', root_result
+      generator.generate
+    end
+
+    it "should copy the kilt.rb file as an app initializer" do
+      root_result = Object.new
+      root.stubs(:join).with('config', 'initializers', 'kilt.rb').returns root_result
+      generator.expects(:copy_file).with 'kilt.rb', root_result
+      generator.generate
+    end
+
+    it "should inject the Kilt routes into the app's routes" do
+      root_result = Object.new
+      root.stubs(:join).with('config', 'routes.rb').returns root_result
+      generator.expects(:inject_into_file).with root_result, "\n\tmount Kilt::Engine => '/admin', as: 'kilt_engine'\n", :after => "Test::Application.routes.draw do\n"
       generator.generate
     end
 

--- a/test/kilt/utils_spec.rb
+++ b/test/kilt/utils_spec.rb
@@ -13,6 +13,8 @@ describe Kilt::Utils do
           ENV.stubs(:[]).with('RAILS_ENV').returns environment
         end
 
+        after { Kilt::Utils.instance_eval { @database = nil } }
+
         it "should return a new Kilt database" do
 
           database  = Object.new
@@ -76,6 +78,8 @@ describe Kilt::Utils do
           Kilt::Utils.instance_eval { @database = nil }
           ENV.stubs(:[]).with('RAILS_ENV').returns environment
         end
+
+        after { Kilt::Utils.instance_eval { @database = nil } }
 
         it "should return a new Kilt database with the development config" do
 

--- a/test/kilt/utils_spec.rb
+++ b/test/kilt/utils_spec.rb
@@ -29,6 +29,22 @@ describe Kilt::Utils do
 
         end
 
+        it "should return the same Kilt database everytime it is called" do
+
+          database  = Object.new
+
+          Kilt.stubs(:config).returns Object.new
+          Kilt.config.stubs(environment.to_sym).returns Object.new
+          Kilt.config.send(environment.to_sym).stubs(:db).returns Object.new
+
+          Kilt::Database.expects(:new)
+                        .with(Kilt.config.send(environment.to_sym).db)
+                        .returns database
+
+          Kilt::Utils.database.must_be_same_as Kilt::Utils.database
+
+        end
+
       end
 
     end

--- a/test/kilt/utils_spec.rb
+++ b/test/kilt/utils_spec.rb
@@ -45,6 +45,25 @@ describe Kilt::Utils do
 
         end
 
+        describe "when config is done the old Kilt way, with a single 'db'" do
+
+          it "should return a new Kilt database with the development config" do
+
+            database  = Object.new
+
+            Kilt.stubs(:config).returns Object.new
+            Kilt.config.stubs(:db).returns Object.new
+
+            Kilt::Database.stubs(:new)
+                          .with(Kilt.config.db)
+                          .returns database
+
+            Kilt::Utils.database.must_be_same_as database
+
+          end
+
+        end
+
       end
 
     end

--- a/test/kilt/utils_spec.rb
+++ b/test/kilt/utils_spec.rb
@@ -1,0 +1,32 @@
+require File.expand_path(File.dirname(__FILE__) + '/../minitest_helper')
+
+describe Kilt::Utils do
+
+  describe "database" do
+
+    describe "when current environment is test" do
+
+      describe "and is called once" do
+
+        before { Kilt::Utils.instance_eval { @database = nil } }
+
+        it "should return a new Kilt database" do
+
+          database  = Object.new
+
+          Kilt.stubs(:config).returns Object.new
+          Kilt.config.stubs(:test).returns Object.new
+          Kilt.config.test.stubs(:db).returns Object.new
+
+          Kilt::Database.stubs(:new).with(Kilt.config.test.db).returns database
+          Kilt::Utils.database.must_be_same_as database
+
+        end
+
+      end
+
+    end
+
+  end
+
+end

--- a/test/kilt/utils_spec.rb
+++ b/test/kilt/utils_spec.rb
@@ -2,6 +2,19 @@ require File.expand_path(File.dirname(__FILE__) + '/../minitest_helper')
 
 describe Kilt::Utils do
 
+  describe "setting up the database" do
+    it "should call setup on the current database" do
+
+      database = Object.new
+      Kilt::Utils.stubs(:database).returns database
+
+      database.expects(:setup!)
+
+      Kilt::Utils.setup_db
+        
+    end
+  end
+
   describe "database" do
 
     ['test', 'development', 'production'].each do |environment|

--- a/test/kilt/utils_spec.rb
+++ b/test/kilt/utils_spec.rb
@@ -8,28 +8,24 @@ describe Kilt::Utils do
 
       describe "when current environment is #{environment}" do
 
-        describe "and is called once" do
+        before do
+          Kilt::Utils.instance_eval { @database = nil }
+          ENV.stubs(:[]).with('RAILS_ENV').returns environment
+        end
 
-          before do
-            Kilt::Utils.instance_eval { @database = nil }
-            ENV.stubs(:[]).with('RAILS_ENV').returns environment
-          end
+        it "should return a new Kilt database" do
 
-          it "should return a new Kilt database" do
+          database  = Object.new
 
-            database  = Object.new
+          Kilt.stubs(:config).returns Object.new
+          Kilt.config.stubs(environment.to_sym).returns Object.new
+          Kilt.config.send(environment.to_sym).stubs(:db).returns Object.new
 
-            Kilt.stubs(:config).returns Object.new
-            Kilt.config.stubs(environment.to_sym).returns Object.new
-            Kilt.config.send(environment.to_sym).stubs(:db).returns Object.new
+          Kilt::Database.stubs(:new)
+                        .with(Kilt.config.send(environment.to_sym).db)
+                        .returns database
 
-            Kilt::Database.stubs(:new)
-                          .with(Kilt.config.send(environment.to_sym).db)
-                          .returns database
-
-            Kilt::Utils.database.must_be_same_as database
-
-          end
+          Kilt::Utils.database.must_be_same_as database
 
         end
 

--- a/test/kilt/utils_spec.rb
+++ b/test/kilt/utils_spec.rb
@@ -4,22 +4,32 @@ describe Kilt::Utils do
 
   describe "database" do
 
-    describe "when current environment is test" do
+    ['test', 'development', 'production'].each do |environment|
 
-      describe "and is called once" do
+      describe "when current environment is #{environment}" do
 
-        before { Kilt::Utils.instance_eval { @database = nil } }
+        describe "and is called once" do
 
-        it "should return a new Kilt database" do
+          before do
+            Kilt::Utils.instance_eval { @database = nil }
+            ENV.stubs(:[]).with('RAILS_ENV').returns environment
+          end
 
-          database  = Object.new
+          it "should return a new Kilt database" do
 
-          Kilt.stubs(:config).returns Object.new
-          Kilt.config.stubs(:test).returns Object.new
-          Kilt.config.test.stubs(:db).returns Object.new
+            database  = Object.new
 
-          Kilt::Database.stubs(:new).with(Kilt.config.test.db).returns database
-          Kilt::Utils.database.must_be_same_as database
+            Kilt.stubs(:config).returns Object.new
+            Kilt.config.stubs(environment.to_sym).returns Object.new
+            Kilt.config.send(environment.to_sym).stubs(:db).returns Object.new
+
+            Kilt::Database.stubs(:new)
+                          .with(Kilt.config.send(environment.to_sym).db)
+                          .returns database
+
+            Kilt::Utils.database.must_be_same_as database
+
+          end
 
         end
 

--- a/test/kilt/utils_spec.rb
+++ b/test/kilt/utils_spec.rb
@@ -49,6 +49,35 @@ describe Kilt::Utils do
 
     end
 
+    ['', nil].each do |environment|
+
+      describe "when current environment is #{environment}" do
+
+        before do
+          Kilt::Utils.instance_eval { @database = nil }
+          ENV.stubs(:[]).with('RAILS_ENV').returns environment
+        end
+
+        it "should return a new Kilt database with the development config" do
+
+          database  = Object.new
+
+          Kilt.stubs(:config).returns Object.new
+          Kilt.config.stubs(:development).returns Object.new
+          Kilt.config.send(:development).stubs(:db).returns Object.new
+
+          Kilt::Database.stubs(:new)
+                        .with(Kilt.config.send(:development).db)
+                        .returns database
+
+          Kilt::Utils.database.must_be_same_as database
+
+        end
+
+      end
+
+    end
+
   end
 
 end

--- a/test/kilt/utils_spec.rb
+++ b/test/kilt/utils_spec.rb
@@ -20,11 +20,11 @@ describe Kilt::Utils do
           database  = Object.new
 
           Kilt.stubs(:config).returns Object.new
-          Kilt.config.stubs(environment.to_sym).returns Object.new
-          Kilt.config.send(environment.to_sym).stubs(:db).returns Object.new
+          Kilt.config.stubs(:[]).with(environment.to_sym).returns Object.new
+          Kilt.config[environment.to_sym].stubs(:db).returns Object.new
 
           Kilt::Database.stubs(:new)
-                        .with(Kilt.config.send(environment.to_sym).db)
+                        .with(Kilt.config[environment.to_sym].db)
                         .returns database
 
           Kilt::Utils.database.must_be_same_as database
@@ -36,11 +36,11 @@ describe Kilt::Utils do
           database  = Object.new
 
           Kilt.stubs(:config).returns Object.new
-          Kilt.config.stubs(environment.to_sym).returns Object.new
-          Kilt.config.send(environment.to_sym).stubs(:db).returns Object.new
+          Kilt.config.stubs(:[]).with(environment.to_sym).returns Object.new
+          Kilt.config[environment.to_sym].stubs(:db).returns Object.new
 
           Kilt::Database.expects(:new)
-                        .with(Kilt.config.send(environment.to_sym).db)
+                        .with(Kilt.config[environment.to_sym].db)
                         .returns database
 
           Kilt::Utils.database.must_be_same_as Kilt::Utils.database
@@ -86,11 +86,11 @@ describe Kilt::Utils do
           database  = Object.new
 
           Kilt.stubs(:config).returns Object.new
-          Kilt.config.stubs(:development).returns Object.new
-          Kilt.config.send(:development).stubs(:db).returns Object.new
+          Kilt.config.stubs(:[]).with(:development).returns Object.new
+          Kilt.config[:development].stubs(:db).returns Object.new
 
           Kilt::Database.stubs(:new)
-                        .with(Kilt.config.send(:development).db)
+                        .with(Kilt.config[:development].db)
                         .returns database
 
           Kilt::Utils.database.must_be_same_as database

--- a/test/kilt_spec.rb
+++ b/test/kilt_spec.rb
@@ -103,7 +103,7 @@ describe Kilt do
       describe "when creating a record fails" do
 
         it "should return false" do
-          Kilt::Utils.stubs(:db).returns( { 'errors' => error_count } )
+          Kilt::Database.any_instance.stubs(:execute).returns( { 'errors' => error_count } )
           object = Kilt::Object.new('dog', { 'name' => 'A name.' } )
           Kilt.create(object).must_equal false
         end
@@ -378,7 +378,7 @@ describe Kilt do
     end
 
     it "should return false if the delete returned errors" do
-      Kilt::Utils.stubs(:db).returns( { 'errors' => 1 } )
+      Kilt::Database.any_instance.stubs(:execute).returns( { 'errors' => 1 } )
       Kilt.delete(object['slug']).must_equal false
     end
 

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -13,8 +13,11 @@ require 'mocha/setup'
 
 def default_test_config
   config         = Hashie::Mash.new
-  config.db      = Hashie::Mash.new(db: 'kilt_test', host: '127.0.0.1', port: '28015')
-  config.name    = 'Test App'
+
+  config.test         = Hashie::Mash.new
+  config.test.db      = Hashie::Mash.new(db: 'kilt_test', host: '127.0.0.1', port: '28015')
+  config.test.name    = 'Test App'
+
   config.objects = Hashie::Mash.new(cat: Hashie::Mash.new(fields: { name: 'text', size: 'text', headshot: 'image', resume: 'file' } ),
                                     dog: Hashie::Mash.new(fields: { name: 'text', size: 'text', headshot: 'image', resume: 'file' } ),
                                     no_namey: Hashie::Mash.new(fields: { } ))
@@ -32,7 +35,7 @@ end
 
 def clear_out_the_database
   Kilt::Utils.database.execute do
-    r.db(Kilt.config.db.db).table('objects').delete().run
+    r.db(Kilt.config.test.db.db).table('objects').delete().run
   end
 end
 

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -27,7 +27,7 @@ end
 
 def setup_the_database_with config
   Kilt.config = config
-  Kilt::Utils.rethink_setup_db
+  Kilt::Utils.setup_db
 end
 
 def clear_out_the_database

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -31,7 +31,7 @@ def setup_the_database_with config
 end
 
 def clear_out_the_database
-  Kilt::Utils.db do
+  Kilt::Database.new(:host => Kilt.config.db.host, :port => Kilt.config.db.port).execute do
     r.db(Kilt.config.db.db).table('objects').delete().run
   end
 end

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -31,7 +31,7 @@ def setup_the_database_with config
 end
 
 def clear_out_the_database
-  Kilt::Database.new(:host => Kilt.config.db.host, :port => Kilt.config.db.port).execute do
+  Kilt::Database.new(Kilt.config.db).execute do
     r.db(Kilt.config.db.db).table('objects').delete().run
   end
 end

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -16,8 +16,8 @@ def default_test_config
 
   config.test         = Hashie::Mash.new
   config.test.db      = Hashie::Mash.new(db: 'kilt_test', host: '127.0.0.1', port: '28015')
-  config.test.name    = 'Test App'
 
+  config.name    = 'Test App'
   config.objects = Hashie::Mash.new(cat: Hashie::Mash.new(fields: { name: 'text', size: 'text', headshot: 'image', resume: 'file' } ),
                                     dog: Hashie::Mash.new(fields: { name: 'text', size: 'text', headshot: 'image', resume: 'file' } ),
                                     no_namey: Hashie::Mash.new(fields: { } ))

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -31,7 +31,7 @@ def setup_the_database_with config
 end
 
 def clear_out_the_database
-  Kilt::Database.new(Kilt.config.db).execute do
+  Kilt::Utils.database.execute do
     r.db(Kilt.config.db.db).table('objects').delete().run
   end
 end

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -27,7 +27,7 @@ end
 
 def setup_the_database_with config
   Kilt.config = config
-  Kilt::Utils.setup_db
+  Kilt::Utils.rethink_setup_db
 end
 
 def clear_out_the_database


### PR DESCRIPTION
Not ready for production, and currently dependent on #22 and #23.  I'm passing this along for review.

We talked about having different levels of config for different environments.  Given the changes in #23, it's relatively trivial to do this... just inject the appropriate configuration to the database object in the Kilt::Utils.database method.  

If the other pull requests were merged, here you would see that Kilt::Utils.database switch, as well as a bunch of tests that I wrote around every method I touched.
