### PR TITLE
Slug prefixes

### DIFF
--- a/lib/kilt.rb
+++ b/lib/kilt.rb
@@ -98,7 +98,7 @@ module Kilt
       result = slug_is_unique_for?(slug, object) ? slug
                                                  : "#{slug}-#{(Time.now.to_f * 1000).to_i}"
       if prefix = Kilt.send(object.type.to_sym)['slug_prefix']
-        "#{prefix}-happy-camper"
+        "#{prefix}-#{slug}"
       else
         result
       end

--- a/lib/kilt.rb
+++ b/lib/kilt.rb
@@ -95,13 +95,11 @@ module Kilt
     def slug_for object
       slug = object['slug'].to_s.strip == '' ? Utils.slugify(object['name'])
                                              : "#{object['slug']}"
+      if prefix = Kilt.send(object.type.to_sym)['slug_prefix']
+        slug = "#{prefix}-#{slug}"
+      end
       result = slug_is_unique_for?(slug, object) ? slug
                                                  : "#{slug}-#{(Time.now.to_f * 1000).to_i}"
-      if prefix = Kilt.send(object.type.to_sym)['slug_prefix']
-        "#{prefix}-#{slug}"
-      else
-        result
-      end
     end
 
   end

--- a/lib/kilt.rb
+++ b/lib/kilt.rb
@@ -96,7 +96,7 @@ module Kilt
       slug = object['slug'].to_s.strip == '' ? Utils.slugify(object['name'])
                                              : "#{object['slug']}"
       if prefix = Kilt.send(object['type'].to_sym)['slug_prefix']
-        unless slug.starts_with?(prefix)
+        unless slug.starts_with?(prefix) && slug != prefix
           slug = "#{prefix}-#{slug}"
         end
       end

--- a/lib/kilt.rb
+++ b/lib/kilt.rb
@@ -121,10 +121,8 @@ module Kilt
     def prefix_for object
       return nil unless prefix = lookup_the_suggested_prefix_for(object)
       slug = slugified_value_for object
-      unless slug.starts_with?(prefix) && slug != prefix
-        return prefix
-      end
-      nil
+      slug.starts_with?(prefix) && slug != prefix ? nil
+                                                  : prefix
     end
 
     def lookup_the_suggested_prefix_for object

--- a/lib/kilt.rb
+++ b/lib/kilt.rb
@@ -119,13 +119,16 @@ module Kilt
     end
 
     def prefix_for object
-      if prefix = Kilt.send(object['type'].to_sym)['slug_prefix']
-        slug = slugified_value_for object
-        unless slug.starts_with?(prefix) && slug != prefix
-          return prefix
-        end
+      return nil unless prefix = lookup_the_suggested_prefix_for(object)
+      slug = slugified_value_for object
+      unless slug.starts_with?(prefix) && slug != prefix
+        return prefix
       end
       nil
+    end
+
+    def lookup_the_suggested_prefix_for object
+      Kilt.send(object['type'].to_sym)['slug_prefix']
     end
 
   end

--- a/lib/kilt.rb
+++ b/lib/kilt.rb
@@ -93,13 +93,17 @@ module Kilt
     end
 
     def slug_for object
-      slug = object['slug'].to_s.strip == '' ? Utils.slugify(object['name'])
-                                             : "#{object['slug']}"
-      if prefix = Kilt.send(object['type'].to_sym)['slug_prefix']
-        unless slug.starts_with?(prefix) && slug != prefix
-          slug = "#{prefix}-#{slug}"
-        end
-      end
+      slug = if object['slug'].to_s.strip == ''
+               slug = Utils.slugify(object['name'])
+               if prefix = Kilt.send(object['type'].to_sym)['slug_prefix']
+                 unless slug.starts_with?(prefix) && slug != prefix
+                   slug = "#{prefix}-#{slug}"
+                 end
+               end
+               slug
+             else
+               "#{object['slug']}"
+             end
       result = slug_is_unique_for?(slug, object) ? slug
                                                  : "#{slug}-#{(Time.now.to_f * 1000).to_i}"
     end

--- a/lib/kilt.rb
+++ b/lib/kilt.rb
@@ -93,17 +93,25 @@ module Kilt
     end
 
     def slug_for object
-      slug = if object['slug'].to_s.strip == ''
-               if prefix = prefix_for(object)
-                 "#{prefix}-#{slugified_value_for(object)}"
-               else
-                 slugified_value_for(object)
-               end
-             else
-               "#{object['slug']}"
-             end
-      result = slug_is_unique_for?(slug, object) ? slug
-                                                 : "#{slug}-#{(Time.now.to_f * 1000).to_i}"
+      slug = possibly_duplicate_slug_for object
+      slug_is_unique_for?(slug, object) ? slug
+                                        : make_slug_unique(slug)
+    end
+
+    def make_slug_unique slug
+      "#{slug}-#{(Time.now.to_f * 1000).to_i}"
+    end
+
+    def possibly_duplicate_slug_for object
+      if object['slug'].to_s.strip == ''
+        if prefix = prefix_for(object)
+          "#{prefix}-#{slugified_value_for(object)}"
+        else
+          slugified_value_for(object)
+        end
+      else
+        "#{object['slug']}"
+      end
     end
 
     def slugified_value_for object

--- a/lib/kilt.rb
+++ b/lib/kilt.rb
@@ -95,7 +95,7 @@ module Kilt
     def slug_for object
       slug = if object['slug'].to_s.strip == ''
                slug = Utils.slugify(object['name'])
-               if prefix = prefix_for(object, slug)
+               if prefix = prefix_for(object)
                  slug = "#{prefix}-#{slug}"
                end
                slug
@@ -106,7 +106,8 @@ module Kilt
                                                  : "#{slug}-#{(Time.now.to_f * 1000).to_i}"
     end
 
-    def prefix_for object, slug
+    def prefix_for object
+      slug = Utils.slugify(object['name'])
       if prefix = Kilt.send(object['type'].to_sym)['slug_prefix']
         unless slug.starts_with?(prefix) && slug != prefix
           return prefix

--- a/lib/kilt.rb
+++ b/lib/kilt.rb
@@ -95,8 +95,10 @@ module Kilt
     def slug_for object
       slug = object['slug'].to_s.strip == '' ? Utils.slugify(object['name'])
                                              : "#{object['slug']}"
-      if prefix = Kilt.send(object.type.to_sym)['slug_prefix']
-        slug = "#{prefix}-#{slug}"
+      if prefix = Kilt.send(object['type'].to_sym)['slug_prefix']
+        unless slug.starts_with?(prefix)
+          slug = "#{prefix}-#{slug}"
+        end
       end
       result = slug_is_unique_for?(slug, object) ? slug
                                                  : "#{slug}-#{(Time.now.to_f * 1000).to_i}"

--- a/lib/kilt.rb
+++ b/lib/kilt.rb
@@ -97,8 +97,8 @@ module Kilt
                                              : "#{object['slug']}"
       result = slug_is_unique_for?(slug, object) ? slug
                                                  : "#{slug}-#{(Time.now.to_f * 1000).to_i}"
-      if Kilt.send(object.type.to_sym)['slug_prefix']
-        'a-prefix-happy-camper'
+      if prefix = Kilt.send(object.type.to_sym)['slug_prefix']
+        "#{prefix}-happy-camper"
       else
         result
       end

--- a/lib/kilt.rb
+++ b/lib/kilt.rb
@@ -95,10 +95,8 @@ module Kilt
     def slug_for object
       slug = if object['slug'].to_s.strip == ''
                slug = Utils.slugify(object['name'])
-               if prefix = Kilt.send(object['type'].to_sym)['slug_prefix']
-                 unless slug.starts_with?(prefix) && slug != prefix
-                   slug = "#{prefix}-#{slug}"
-                 end
+               if prefix = prefix_for(object, slug)
+                 slug = "#{prefix}-#{slug}"
                end
                slug
              else
@@ -106,6 +104,15 @@ module Kilt
              end
       result = slug_is_unique_for?(slug, object) ? slug
                                                  : "#{slug}-#{(Time.now.to_f * 1000).to_i}"
+    end
+
+    def prefix_for object, slug
+      if prefix = Kilt.send(object['type'].to_sym)['slug_prefix']
+        unless slug.starts_with?(prefix) && slug != prefix
+          return prefix
+        end
+      end
+      nil
     end
 
   end

--- a/lib/kilt.rb
+++ b/lib/kilt.rb
@@ -94,11 +94,11 @@ module Kilt
 
     def slug_for object
       slug = if object['slug'].to_s.strip == ''
-               slug = Utils.slugify(object['name'])
                if prefix = prefix_for(object)
-                 slug = "#{prefix}-#{slug}"
+                 "#{prefix}-#{slugified_value_for(object)}"
+               else
+                 slugified_value_for(object)
                end
-               slug
              else
                "#{object['slug']}"
              end
@@ -106,9 +106,13 @@ module Kilt
                                                  : "#{slug}-#{(Time.now.to_f * 1000).to_i}"
     end
 
+    def slugified_value_for object
+      Utils.slugify(object['name'])
+    end
+
     def prefix_for object
-      slug = Utils.slugify(object['name'])
       if prefix = Kilt.send(object['type'].to_sym)['slug_prefix']
+        slug = slugified_value_for object
         unless slug.starts_with?(prefix) && slug != prefix
           return prefix
         end

--- a/lib/kilt.rb
+++ b/lib/kilt.rb
@@ -95,8 +95,13 @@ module Kilt
     def slug_for object
       slug = object['slug'].to_s.strip == '' ? Utils.slugify(object['name'])
                                              : "#{object['slug']}"
-      slug_is_unique_for?(slug, object) ? slug
-                                        : "#{slug}-#{(Time.now.to_f * 1000).to_i}"
+      result = slug_is_unique_for?(slug, object) ? slug
+                                                 : "#{slug}-#{(Time.now.to_f * 1000).to_i}"
+      if Kilt.send(object.type.to_sym)['slug_prefix']
+        'a-prefix-happy-camper'
+      else
+        result
+      end
     end
 
   end

--- a/test/kilt_spec.rb
+++ b/test/kilt_spec.rb
@@ -422,11 +422,11 @@ describe Kilt do
   describe "slug prefixes" do
 
     [
-      ['prefix_holder',  :prefix_holders,   'Happy Camper',  'a-prefix-happy-camper'],
-      ['another_prefix', :another_prefixes, 'Happy Camper',  'another-happy-camper'],
-      ['prefix_holder',  :prefix_holders,   'Sad Camper',    'a-prefix-sad-camper'],
-      ['another_prefix', :another_prefixes, 'Amused Camper', 'another-amused-camper'],
-    ].map { |x| Struct.new(:type, :plural_type, :name, :expected_slug).new(*x) }.each do |scenario|
+      ['prefix_holder',  :prefix_holders,   'Happy Camper',  'a-prefix-happy-camper', 'a-prefix'],
+      ['another_prefix', :another_prefixes, 'Happy Camper',  'another-happy-camper',  'another'],
+      ['prefix_holder',  :prefix_holders,   'Sad Camper',    'a-prefix-sad-camper',   'a-prefix'],
+      ['another_prefix', :another_prefixes, 'Amused Camper', 'another-amused-camper', 'another'],
+    ].map { |x| Struct.new(:type, :plural_type, :name, :expected_slug, :the_prefix).new(*x) }.each do |scenario|
 
       describe "creating an object with a slug prefix" do
 
@@ -435,6 +435,17 @@ describe Kilt do
           Kilt.create object
 
           object['slug'].must_equal scenario.expected_slug
+        end
+
+        describe "when creating a record that naturally will conflict with a prefix" do
+          it "should still append the appropriate slug" do
+            object = Kilt::Object.new(scenario.type, { 'name' => scenario.the_prefix } )
+
+            Kilt.create object
+
+            object['slug'].must_equal "#{scenario.the_prefix}-#{scenario.the_prefix}"
+                
+          end
         end
 
       end

--- a/test/kilt_spec.rb
+++ b/test/kilt_spec.rb
@@ -419,4 +419,19 @@ describe Kilt do
 
   end
 
+  describe "slug prefixes" do
+
+    describe "creating an object with a slug prefix" do
+
+      it "should prepend the slug prefix to the slug" do
+        object = Kilt::Object.new('prefix_holder', { 'name' => 'Happy Camper' } )
+        Kilt.create object
+
+        object['slug'].must_equal 'a-prefix-happy-camper'
+      end
+
+    end
+
+  end
+
 end

--- a/test/kilt_spec.rb
+++ b/test/kilt_spec.rb
@@ -421,13 +421,20 @@ describe Kilt do
 
   describe "slug prefixes" do
 
-    describe "creating an object with a slug prefix" do
+    [
+      ['prefix_holder',  'Happy Camper', 'a-prefix-happy-camper'],
+      ['another_prefix', 'Happy Camper', 'another-happy-camper'],
+    ].map { |x| Struct.new(:type, :name, :expected_slug).new(*x) }.each do |scenario|
 
-      it "should prepend the slug prefix to the slug" do
-        object = Kilt::Object.new('prefix_holder', { 'name' => 'Happy Camper' } )
-        Kilt.create object
+      describe "creating an object with a slug prefix" do
 
-        object['slug'].must_equal 'a-prefix-happy-camper'
+        it "should prepend the slug prefix to the slug" do
+          object = Kilt::Object.new(scenario.type, { 'name' => scenario.name } )
+          Kilt.create object
+
+          object['slug'].must_equal scenario.expected_slug
+        end
+
       end
 
     end

--- a/test/kilt_spec.rb
+++ b/test/kilt_spec.rb
@@ -422,11 +422,11 @@ describe Kilt do
   describe "slug prefixes" do
 
     [
-      ['prefix_holder',  'Happy Camper',  'a-prefix-happy-camper'],
-      ['another_prefix', 'Happy Camper',  'another-happy-camper'],
-      ['prefix_holder',  'Sad Camper',    'a-prefix-sad-camper'],
-      ['another_prefix', 'Amused Camper', 'another-amused-camper'],
-    ].map { |x| Struct.new(:type, :name, :expected_slug).new(*x) }.each do |scenario|
+      ['prefix_holder',  :prefix_holders,   'Happy Camper',  'a-prefix-happy-camper'],
+      ['another_prefix', :another_prefixes, 'Happy Camper',  'another-happy-camper'],
+      ['prefix_holder',  :prefix_holders,   'Sad Camper',    'a-prefix-sad-camper'],
+      ['another_prefix', :another_prefixes, 'Amused Camper', 'another-amused-camper'],
+    ].map { |x| Struct.new(:type, :plural_type, :name, :expected_slug).new(*x) }.each do |scenario|
 
       describe "creating an object with a slug prefix" do
 
@@ -435,6 +435,24 @@ describe Kilt do
           Kilt.create object
 
           object['slug'].must_equal scenario.expected_slug
+        end
+
+      end
+
+      describe "updating the object later" do
+
+        it "should only have one prefix" do
+          object = Kilt::Object.new(scenario.type, { 'name' => scenario.name } )
+          Kilt.create object
+
+          created_record = Kilt.get(object['slug'])
+          first_slug = created_record['slug']
+
+          Kilt.update created_record['slug'], created_record
+
+          updated_record = Kilt.get(created_record['slug'])
+          updated_record['slug'].must_equal first_slug
+
         end
 
       end

--- a/test/kilt_spec.rb
+++ b/test/kilt_spec.rb
@@ -441,6 +441,30 @@ describe Kilt do
 
     end
 
+    describe "slug conflicts when applying a prefix" do
+
+      describe "when conflicting with the same type on record creation" do
+
+        it "should use the timestamped suffix" do
+
+          Timecop.freeze Time.parse('1/1/2001')
+
+          object = Kilt::Object.new('another_prefix', { 'name' => 'Apple' } )
+          Kilt.create object
+
+          Timecop.freeze Time.now + 1
+
+          object = Kilt::Object.new('another_prefix', { 'name' => 'Apple' } )
+          Kilt.create object
+
+          object['slug'].must_equal 'another-apple-978328801000'
+
+        end
+
+      end
+
+    end
+
   end
 
 end

--- a/test/kilt_spec.rb
+++ b/test/kilt_spec.rb
@@ -422,8 +422,10 @@ describe Kilt do
   describe "slug prefixes" do
 
     [
-      ['prefix_holder',  'Happy Camper', 'a-prefix-happy-camper'],
-      ['another_prefix', 'Happy Camper', 'another-happy-camper'],
+      ['prefix_holder',  'Happy Camper',  'a-prefix-happy-camper'],
+      ['another_prefix', 'Happy Camper',  'another-happy-camper'],
+      ['prefix_holder',  'Sad Camper',    'a-prefix-sad-camper'],
+      ['another_prefix', 'Amused Camper', 'another-amused-camper'],
     ].map { |x| Struct.new(:type, :name, :expected_slug).new(*x) }.each do |scenario|
 
       describe "creating an object with a slug prefix" do

--- a/test/kilt_spec.rb
+++ b/test/kilt_spec.rb
@@ -468,6 +468,35 @@ describe Kilt do
 
       end
 
+      describe "setting the slug manually" do
+
+        describe "creating the record" do
+          it "should not prepend the prefix to the slug" do
+            object = Kilt::Object.new(scenario.type, { 'name' => scenario.name, 'slug' => 'something hardcoded' } )
+            Kilt.create object
+
+            created_record = Kilt.get(object['slug'])
+            created_record['slug'].must_equal 'something hardcoded'
+          end
+        end
+
+        describe "updating the record" do
+
+          it "should not prepend the prefix to the slug" do
+            object = Kilt::Object.new(scenario.type, { 'name' => scenario.name, 'slug' => 'hardcoded value' } )
+            Kilt.create object
+
+            created_record = Kilt.get(object['slug'])
+            Kilt.update created_record['slug'], created_record
+
+            updated_record = Kilt.get(created_record['slug'])
+            created_record['slug'].must_equal 'hardcoded value'
+          end
+
+        end
+
+      end
+
     end
 
     describe "slug conflicts when applying a prefix" do

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -23,6 +23,7 @@ def default_test_config
   config.objects = Hashie::Mash.new(cat: Hashie::Mash.new(fields: { name: 'text', size: 'text', headshot: 'image', resume: 'file' } ),
                                     dog: Hashie::Mash.new(fields: { name: 'text', size: 'text', headshot: 'image', resume: 'file' } ),
                                     no_namey: Hashie::Mash.new(fields: { } ),
+                                    prefix_holder: Hashie::Mash.new(slug_prefix: 'a-prefix', fields: { name: 'text' } ),
                                     horse: Hashie::Mash.new(fields: { name: 'text' } ),
                                     big_green_alligator: Hashie::Mash.new(fields: { name: 'text' } ),
                                     apple: Hashie::Mash.new(name: 'Orange', fields: { name: 'text' } ))

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -24,6 +24,7 @@ def default_test_config
                                     dog: Hashie::Mash.new(fields: { name: 'text', size: 'text', headshot: 'image', resume: 'file' } ),
                                     no_namey: Hashie::Mash.new(fields: { } ),
                                     prefix_holder: Hashie::Mash.new(slug_prefix: 'a-prefix', fields: { name: 'text' } ),
+                                    another_prefix: Hashie::Mash.new(slug_prefix: 'another', fields: { name: 'text' } ),
                                     horse: Hashie::Mash.new(fields: { name: 'text' } ),
                                     big_green_alligator: Hashie::Mash.new(fields: { name: 'text' } ),
                                     apple: Hashie::Mash.new(name: 'Orange', fields: { name: 'text' } ))


### PR DESCRIPTION
Depending on the app that's built with Kilt, there might be some "ancillary" objects -- small CRUD objects that will populate dropdowns, provide groups, etc., but never be exposed as public URLs.  They're still Kilt objects, though, and they will be provided a unique slug.  

Their slug can get in the way, though.  Here's a story:

Setup:

``` yaml
  page:
    fields:
      name: text
      body: tinymce
  blog_category:
    slug_prefix: 'blog-category'
    fields:
      name: text
```

> A user creates a blog category called "Alternative Energy"  The blog category (which will never be exposed as a page) is slugged as "alternative-energy".  Then the user creates a page called "Alternative Energy" with the intention of the page being exposed as a URL.  But since the blog category took up "alternative-energy", the public page gets the nasty-looking "alterative-energy-19287319273" URL.

I thought a quick way to take care of this potential problem is to allow a conditional `slug_prefix` value on an object.  If this slug prefix exists, and system-generated slugs will prepend `slug_prefix` to the slug.  So in the story above, the blog category would get "blog-category-alternative-energy' and the page would get "alternative-energy".

Thoughts, concerns?  I wanted to document this as well, but I didn't see a good place to do it beyond putting it in a default file.  Later on we should talk about documenting this app, I know it well now and think I can help.
