### PR TITLE
jquery-ui-rails

### DIFF
--- a/kilt-cms.gemspec
+++ b/kilt-cms.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rethinkdb'
   s.add_dependency 'rails_config'
   s.add_dependency 'jquery-rails'
-  s.add_dependency 'jquery-ui-rails'
+  s.add_dependency 'jquery-ui-rails', '4.2.1'
   s.add_dependency 'uglifier'
   s.add_dependency 'aws-sdk'
 


### PR DESCRIPTION
This gem was updated over the holiday weekend to v5.  It has breaking changes, which breaks Kilt as the version is not specified.

The app should be updated to support 5, but in the meantime this update will keep Kilt working.
