### PR TITLE
View model

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,10 +9,7 @@ Rake::TestTask.new(:test) do |t|
   t.verbose = true
 end
 
-Rake::TestTask.new(:test_with_rethinkdb) do |t|
-  ENV['RAILS_ENV'] = 'test'
-  ENV['TEST_WITH_RETHINKDB'] = 'true'
-  t.libs << 'test'
-  t.test_files = FileList['test/**/*_test.rb', 'test/**/*_spec.rb']
-  t.verbose = true
+desc "Run the tests with rethinkdb"
+task :test_with_rethinkdb do
+  puts `TEST_WITH_RETHINKDB=true bundle exec rake`
 end

--- a/Rakefile
+++ b/Rakefile
@@ -8,3 +8,11 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/**/*_test.rb', 'test/**/*_spec.rb']
   t.verbose = true
 end
+
+Rake::TestTask.new(:test_with_rethinkdb) do |t|
+  ENV['RAILS_ENV'] = 'test'
+  ENV['TEST_WITH_RETHINKDB'] = 'true'
+  t.libs << 'test'
+  t.test_files = FileList['test/**/*_test.rb', 'test/**/*_spec.rb']
+  t.verbose = true
+end

--- a/lib/kilt.rb
+++ b/lib/kilt.rb
@@ -1,5 +1,6 @@
 require "kilt/base"
 require_relative "kilt_object"
+require_relative "kilt_view_model"
 
 # Include the Rethink shortcut module, which will among other things instantiate a new
 # Rethink object (as "r") if needed

--- a/lib/kilt_view_model.rb
+++ b/lib/kilt_view_model.rb
@@ -1,0 +1,48 @@
+class KiltViewModel
+
+  def self.build input
+    this_is_a_collection(input) ? build_view_models_from(input)
+                                : build_a_view_model_from(input)
+  end
+
+  def initialize subject = {}
+    @subject = subject
+  end
+
+  def [] id
+    @subject[id.to_s] || @subject[id.to_s.to_sym]
+  end
+
+  def method_missing(meth, *args, &blk)
+    @subject[meth.to_s] || @subject[meth]
+  end
+
+  class << self
+
+    private
+
+    def build_a_view_model_from record
+      eval("#{record['type']}_view_model".classify).new record
+    rescue
+      KiltViewModel.new record
+    end
+
+    def this_is_a_collection input
+      input.is_a?(Array) || input.is_a?(Kilt::ObjectCollection)
+    end
+
+    def build_view_models_from records
+      records.map { |r| build_a_view_model_from r }
+             .sort_by do |x|
+               sequence = x.sequence.to_s.to_i
+               if sequence.to_s != x.sequence.to_s
+                 99999999999
+               else
+                 sequence
+               end
+             end
+    end
+
+  end
+
+end

--- a/lib/kilt_view_model.rb
+++ b/lib/kilt_view_model.rb
@@ -35,11 +35,7 @@ class KiltViewModel
       records.map { |r| build_a_view_model_from r }
              .sort_by do |x|
                sequence = x.sequence.to_s.to_i
-               if sequence.to_s != x.sequence.to_s
-                 99999999999
-               else
-                 sequence
-               end
+               sequence.to_s == x.sequence.to_s ? sequence : 99999999999
              end
     end
 

--- a/test/kilt_spec.rb
+++ b/test/kilt_spec.rb
@@ -15,12 +15,7 @@ describe Kilt do
 
   end
 
-  persistence_models_to_test = [['using active record for persistence', :active_record]]
-  unless ENV['TRAVIS']
-    persistence_models_to_test << ['using rethinkdb for persistence', :rethinkdb]
-  end
-
-  persistence_models_to_test.map { |args| Struct.new(:description, :db_type).new(*args) }.each do |persistence|
+  persistence_models_to_test.each do |persistence|
 
     describe persistence.description do
 

--- a/test/kilt_spec.rb
+++ b/test/kilt_spec.rb
@@ -513,11 +513,12 @@ describe Kilt do
             Kilt.create object
 
             Timecop.freeze Time.now + 1
+            timestamp = (Time.now.to_f * 1000).to_i
 
             object = Kilt::Object.new('another_prefix', { 'name' => 'Apple' } )
             Kilt.create object
 
-            object['slug'].must_equal 'another-apple-978328801000'
+            object['slug'].must_equal "another-apple-#{timestamp}"
 
           end
 

--- a/test/kilt_view_model_spec.rb
+++ b/test/kilt_view_model_spec.rb
@@ -1,0 +1,128 @@
+require File.expand_path(File.dirname(__FILE__) + '/minitest_helper')
+
+class ElephantViewModel < KiltViewModel
+end
+
+class TigerViewModel < KiltViewModel
+end
+
+describe KiltViewModel do
+
+  describe "basic features" do
+
+    it "should serve as a wrapper over a hash" do
+
+      hash = { 'first_name' => 'John', 'last_name' => 'Galt' }
+
+      view_model = KiltViewModel.new hash
+
+      view_model.first_name.must_equal 'John'
+      view_model.last_name.must_equal 'Galt'
+
+    end
+
+    it "should work with symbols as well as strings" do
+
+      hash = { city: 'Olathe', 'state' => 'KS' }
+
+      view_model = KiltViewModel.new hash
+
+      view_model.city.must_equal 'Olathe'
+      view_model.state.must_equal 'KS'
+        
+    end
+
+  end
+
+  describe "building view models" do
+
+    [
+      ['elephant', ElephantViewModel], 
+      ['tiger',    TigerViewModel]
+    ].map { |x| Struct.new(:the_type, :the_class).new(*x) }.each do |example|
+
+      describe "building single view models" do
+
+        it "should use the type to build a view model with a matching name" do
+
+          data = { 'type' => example.the_type }
+
+          view_model = KiltViewModel.build data
+
+          view_model.is_a?(example.the_class).must_equal true
+            
+        end
+
+      end
+
+    end
+
+    describe "building arrays of view models" do
+
+      it "should return an array with each item as the proper type, for arrays" do
+          
+        records = [ { 'type' => 'elephant' },
+                    { 'type' => 'tiger'    } ]
+
+        view_models = KiltViewModel.build records
+
+        view_models.count.must_equal 2
+
+        view_models[0].is_a?(ElephantViewModel).must_equal true
+        view_models[1].is_a?(TigerViewModel).must_equal true
+
+      end
+
+      it "should return an array with each item as the proper type, for KiltCollection" do
+          
+        records = Kilt::ObjectCollection.new([ { 'type' => 'elephant'},
+                                               { 'type' => 'tiger' } ])
+
+        view_models = KiltViewModel.build records
+
+        view_models.count.must_equal 2
+        view_models[0].is_a?(ElephantViewModel).must_equal true
+        view_models[1].is_a?(TigerViewModel).must_equal true
+
+      end
+
+      it "should sort items by a sequence field, if sequence exists" do
+          
+        records = [ { 'name' => 'A', 'sequence' => '3' },
+                    { 'name' => 'B', 'sequence' => '2' },
+                    { 'name' => 'C', 'sequence' => '1' },
+                    { 'name' => 'D', 'sequence' => nil },
+                    { 'name' => 'E', 'sequence' => 'A' }]
+
+        view_models = KiltViewModel.build records
+
+        view_models.count.must_equal 5
+
+        view_models[0].name.must_equal 'C'
+        view_models[1].name.must_equal 'B'
+        view_models[2].name.must_equal 'A'
+        view_models[3].name.must_equal 'D'
+        view_models[4].name.must_equal 'E'
+
+      end
+
+
+    end
+
+    describe "building a view model when none exists" do
+
+      it "should return a KiltViewModel instead" do
+
+        data = { 'type' => 'monkey' }
+
+        view_model = KiltViewModel.build data
+
+        view_model.is_a?(KiltViewModel).must_equal true
+          
+      end
+
+    end
+
+  end
+
+end

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -66,4 +66,12 @@ def clear_out_rethinkdb
 rescue
 end
 
+def persistence_models_to_test
+  models = [['using active record for persistence', :active_record]]
+  unless ENV['TRAVIS']
+    models << ['using rethinkdb for persistence', :rethinkdb]
+  end
+  models.map { |args| Struct.new(:description, :db_type).new(*args) }
+end
+
 setup_the_database

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -68,7 +68,7 @@ end
 
 def persistence_models_to_test
   models = [['using active record for persistence', :active_record]]
-  unless ENV['TRAVIS']
+  if ENV['TEST_WITH_RETHINKDB']
     models << ['using rethinkdb for persistence', :rethinkdb]
   end
   models.map { |args| Struct.new(:description, :db_type).new(*args) }

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -37,7 +37,7 @@ end
 
 def setup_the_database_with config
   Kilt.config = config
-  Kilt::Utils.use_db(:active_record) if ENV['TRAVIS']
+  Kilt::Utils.use_db(:active_record) # default the tests to AR
   Kilt::Utils.setup_db
 end
 


### PR DESCRIPTION
This PR would be easier to assess after #34 is merged.

I like the JSON-only form of the data that Kilt returns, but it can make for some nasty views.  I built a "view model" that lets me do things like this:

``` ruby
first_page = Kilt.pages.first
first_page['name'] # "Home"

view_model  = KiltViewModel.build first_page
# view_model is a KiltViewModel object
view_model.name # "Home"
```

So at its simplest, it lets you use a method call instead of the brackets.  Big deal, right?

Well, you can also do this:

`````` ruby
class PageViewModel < KiltViewModel
  def image
    return nil unless self[:image]
    Kilt::Utils.download_location('image', self[:image])
  end
end

first_page = Kilt.pages.first
view_model = KiltViewModel.build first_page

# view_model is a PageViewModel, since a "PageViewModel" exists.  ```KiltViewModel.build``` will look for a matching ```#{object.object_type}ViewModel``` when building the view model.

view_model.image # will return the image... sure beats that logic in the view!
``````

If you pass a single object to `KiltViewModel.build` it will return a single view model.  If you pass it a set of objects, it will return a set of view models.  Each of the view models in the set will be determined individually... so if you gave it `[Kilt.pages, Kilt.blogs].flatten` you'd get both PageViewModels and BlogViewModels (or KiltViewModels if any of those aren't defined).

I also found it helpful to include some sort of mechanism for sorting, for things like menus and the like.  So if you include a `sequence` field in your schema, `KiltViewModel.build` will sort a set by that field.

**Overall**, this little class can fill in a big hole that appears when passing flat JSON to a view. 
