### PR TITLE
Head and foot for object type

### DIFF
--- a/app/views/kilt/kilt/_field_setup.html.erb
+++ b/app/views/kilt/kilt/_field_setup.html.erb
@@ -1,0 +1,6 @@
+<% Kilt.all_used_fields.each do |field| %>
+  <% begin %>
+    <%= render partial: "kilt/form/#{field}_#{type}" %>
+  <% rescue %>
+  <% end %>
+<% end %>

--- a/app/views/layouts/kilt/cms.html.erb
+++ b/app/views/layouts/kilt/cms.html.erb
@@ -17,6 +17,8 @@
         <%= javascript_include_tag "kilt/application" %>
         
         <%= csrf_meta_tags %>
+
+        <%= render partial: 'kilt/kilt/field_setup', locals: { type: 'head' } %>
 </head>
 <body>
     
@@ -32,5 +34,6 @@
         </div>
     </footer>
     
+    <%= render partial: 'kilt/kilt/field_setup', locals: { type: 'foot' } %>
 </body>
 </html>

--- a/lib/kilt.rb
+++ b/lib/kilt.rb
@@ -78,4 +78,20 @@ module Kilt
     Kilt::ObjectCollection.new results
   end
 
+  # Get every field type used
+  # Returns: Array of strings
+  # Example: Kilt.all_used_fields
+  def self.all_used_fields
+    used_field_types = Kilt.config[:objects].map do |object|
+                         object.map do |config|
+                           begin
+                             config[:fields].map { |_, v| v }
+                           rescue
+                             nil
+                           end
+                         end
+                       end.flatten
+    used_field_types.select { |x| x }.group_by { |x| x }.map { |x| x[0] }
+  end
+
 end

--- a/test/kilt_spec.rb
+++ b/test/kilt_spec.rb
@@ -515,4 +515,14 @@ describe Kilt do
 
   end
 
+  describe "all_used_fields" do
+    it "should return a list of all of the used fields" do
+      fields = Kilt.all_used_fields
+      fields.count.must_equal 3
+      fields.include?("file").must_equal true
+      fields.include?("text").must_equal true
+      fields.include?("image").must_equal true
+    end
+  end
+
 end


### PR DESCRIPTION
Let's say that I want to use filepicker.io to upload my files in the admin.  

With this update, I'd create:

1) kilt/form/_filepicker.html.erb => The filepicker field editor, but with the filepicker HTML.
2) kilt/form/_filepicker_head.html.erb => The JS code that has to be injected into the page head.
3) kilt/form/_filepicker_foot.html.erb => The JS initialization code, which will be injected at the bottom of the page.

If I wanted to do this without the update, I'd have to override the Kilt layout page, and inject the field-specific code into the head and foot.
